### PR TITLE
Inmemory aggregator

### DIFF
--- a/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_one_pushnotification_to_mutiple_tokens_with_aggregator.cs
+++ b/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_one_pushnotification_to_mutiple_tokens_with_aggregator.cs
@@ -32,11 +32,10 @@ namespace PushNotifications.Aggregator.InMemory.Tests
         {
             concreateDelivery.Send(t1, n1);
             concreateDelivery.Send(t2, n1);
-            Thread.Sleep((int)timeSpanBeforeFlush.TotalMilliseconds * 2);
+            Thread.Sleep((int)timeSpanBeforeFlush.TotalMilliseconds * 3);
         };
 
         It should_send_correct_number_of_notifications = () => concreateDelivery.Store.Count().ShouldEqual(2);
-
 
         It should_send_to_correct_first_token = () => concreateDelivery.Store.Where(x => x.Key.Equals(t1)).Count().ShouldEqual(1);
 

--- a/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_pushnotification_with_aggregator_using_timespan_to_flush_and_does_not_wait.cs
+++ b/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_pushnotification_with_aggregator_using_timespan_to_flush_and_does_not_wait.cs
@@ -24,10 +24,7 @@ namespace PushNotifications.Aggregator.InMemory.Tests
             notification = new NotificationForDelivery(new PushNotificationId(Guid.NewGuid().ToString(), "elders"), new NotificationPayload("title", "body"), notificationData, expirationDateOfNotification, true);
         };
 
-        Because of = () =>
-        {
-            Helper.Send(concreateDelivery, countOfRecipients, notification);
-        };
+        Because of = () => Helper.Send(concreateDelivery, countOfRecipients, notification);
 
         It should_have_sent_zero_notifications = () => concreateDelivery.Store.Count().ShouldEqual(0);
 

--- a/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_pushnotification_with_aggregator_using_tokens_count_to_flush.cs
+++ b/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_pushnotification_with_aggregator_using_tokens_count_to_flush.cs
@@ -24,10 +24,7 @@ namespace PushNotifications.Aggregator.InMemory.Tests
             notification = new NotificationForDelivery(new PushNotificationId(Guid.NewGuid().ToString(), "elders"), new NotificationPayload("title", "body"), notificationData, expirationDateOfNotification, true);
         };
 
-        Because of = () =>
-        {
-            Helper.Send(concreateDelivery, countOfRecipients, notification);
-        };
+        Because of = () => Helper.Send(concreateDelivery, countOfRecipients, notification);
 
         It should_have_sent_notifications_to_all_recipients = () => concreateDelivery.Store.Count().ShouldEqual(countOfRecipients);
 

--- a/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_pushnotification_with_aggregator_using_tokens_count_to_flush_and_flush_count_is_not_reached.cs
+++ b/src/PushNotifications.Aggregator.InMemory.Tests/When_sending_pushnotification_with_aggregator_using_tokens_count_to_flush_and_flush_count_is_not_reached.cs
@@ -24,10 +24,7 @@ namespace PushNotifications.Aggregator.InMemory.Tests
             notification = new NotificationForDelivery(new PushNotificationId(Guid.NewGuid().ToString(), "elders"), new NotificationPayload("title", "body"), notificationData, expirationDateOfNotification, true);
         };
 
-        Because of = () =>
-        {
-            Helper.Send(concreateDelivery, countOfRecipients, notification);
-        };
+        Because of = () => Helper.Send(concreateDelivery, countOfRecipients, notification);
 
         It should_have_sent_zero_notifications = () => concreateDelivery.Store.Count().ShouldEqual(0);
 

--- a/src/PushNotifications.Aggregator.InMemory/InMemoryPushNotificationAggregator.cs
+++ b/src/PushNotifications.Aggregator.InMemory/InMemoryPushNotificationAggregator.cs
@@ -13,7 +13,7 @@ namespace PushNotifications.Aggregator.InMemory
     {
         static ILog log = LogProvider.GetLogger(typeof(InMemoryPushNotificationAggregator));
 
-        private static readonly object _lockBuffer = new object();
+        private readonly object _lockBuffer = new object();
 
         Func<List<SubscriptionToken>, NotificationForDelivery, SendTokensResult> send;
 
@@ -91,12 +91,12 @@ namespace PushNotifications.Aggregator.InMemory
                 {
                     if (buffer.Remove(notification))
                         return send(tokens, notification);
+                    else
+                        log.Error($"Failed to remove notification from the {nameof(InMemoryPushNotificationAggregator)} buffer. Most likely the access to the {nameof(buffer)} is not properly synchronized. I suggest you to delete this class and rewrite it.");
                 }
             }
 
-            log.Error($"Failed to remove notification from the {nameof(InMemoryPushNotificationAggregator)} buffer. Most likely the access to the {nameof(buffer)} is not properly synchronized. I suggest you to delete this class and rewrite it.");
-
-            return SendTokensResult.Failed;
+            return SendTokensResult.Success;
         }
 
         void FlushAll()

--- a/src/PushNotifications.Aggregator.InMemory/InMemoryPushNotificationAggregator.cs
+++ b/src/PushNotifications.Aggregator.InMemory/InMemoryPushNotificationAggregator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using PushNotifications.Aggregator.InMemory.Logging;
 using PushNotifications.Contracts;
@@ -10,6 +11,10 @@ namespace PushNotifications.Aggregator.InMemory
 {
     public class InMemoryPushNotificationAggregator : IDisposable, IPushNotificationAggregator
     {
+        static ILog log = LogProvider.GetLogger(typeof(InMemoryPushNotificationAggregator));
+
+        private static readonly object _lockBuffer = new object();
+
         Func<List<SubscriptionToken>, NotificationForDelivery, SendTokensResult> send;
 
         readonly TimeSpan timeSpanBeforeFlush;
@@ -20,9 +25,7 @@ namespace PushNotifications.Aggregator.InMemory
 
         bool canSend;
 
-        ConcurrentDictionary<NotificationForDelivery, List<SubscriptionToken>> buffer;
-
-        static ILog log = LogProvider.GetLogger(typeof(InMemoryPushNotificationAggregator));
+        Dictionary<NotificationForDelivery, List<SubscriptionToken>> buffer;
 
         /// <summary>
         /// Aggregates push notifications and flushes them as single batch
@@ -40,8 +43,8 @@ namespace PushNotifications.Aggregator.InMemory
             this.timeSpanBeforeFlush = timeSpanBeforeFlush;
             this.recipientsCountBeforeFlush = recipientsCountBeforeFlush;
             canSend = true;
-            buffer = new ConcurrentDictionary<NotificationForDelivery, List<SubscriptionToken>>();
-            timer = new Timer(x => Flush(), this, TimeSpan.FromSeconds(0), timeSpanBeforeFlush);
+            buffer = new Dictionary<NotificationForDelivery, List<SubscriptionToken>>(new NotificationForDeliveryEqualityComparer());
+            timer = new Timer(x => FlushAll(), 1, TimeSpan.FromSeconds(0), timeSpanBeforeFlush);
         }
 
         public SendTokensResult Queue(SubscriptionToken token, NotificationForDelivery notification)
@@ -49,49 +52,84 @@ namespace PushNotifications.Aggregator.InMemory
             if (ReferenceEquals(null, token) == true) throw new ArgumentNullException(nameof(token));
             if (ReferenceEquals(null, notification) == true) throw new ArgumentNullException(nameof(notification));
 
-            if (canSend == false)
-            {
-                log.Error($"The InMemoryPushNotificationAggregator cannot send. Token {token} and notification {notification.NotificationPayload}");
-                return SendTokensResult.Success;
-            }
-
             if (timeSpanBeforeFlush == TimeSpan.Zero || recipientsCountBeforeFlush == 1)
                 return send(new List<SubscriptionToken> { token }, notification);
 
-            buffer.AddOrUpdate(notification, new List<SubscriptionToken> { token }, (k, v) => { v.Add(token); return v; });
+            if (canSend == false)
+            {
+                log.Error($"The InMemoryPushNotificationAggregator cannot send. Token {token} and notification {notification.NotificationPayload}");
+                return SendTokensResult.Failed;
+            }
 
-            List<SubscriptionToken> tokens;
-            if (buffer.TryGetValue(notification, out tokens) && tokens.Count >= recipientsCountBeforeFlush)
-                return Flush();
+            lock (_lockBuffer)
+            {
+                List<SubscriptionToken> tokens;
+                if (buffer.TryGetValue(notification, out tokens))
+                {
+                    tokens.Add(token);
+                    if (tokens.Count >= recipientsCountBeforeFlush)
+                    {
+                        if (buffer.Remove(notification))
+                            return send(tokens, notification);
+                    }
+                }
+                else
+                {
+                    buffer.Add(notification, new List<SubscriptionToken>() { token });
+                }
+            }
 
             return SendTokensResult.Success;
         }
 
-        SendTokensResult Flush()
+        SendTokensResult Flush(NotificationForDelivery notification)
         {
-            foreach (var key in buffer.Keys)
+            lock (_lockBuffer)
             {
                 List<SubscriptionToken> tokens;
-                if (buffer.TryRemove(key, out tokens))
+                if (buffer.TryGetValue(notification, out tokens))
                 {
-                    return send(tokens, key);
+                    if (buffer.Remove(notification))
+                        return send(tokens, notification);
                 }
             }
-            return SendTokensResult.Success;
+
+            log.Error($"Failed to remove notification from the {nameof(InMemoryPushNotificationAggregator)} buffer. Most likely the access to the {nameof(buffer)} is not properly synchronized. I suggest you to delete this class and rewrite it.");
+
+            return SendTokensResult.Failed;
+        }
+
+        void FlushAll()
+        {
+            log.Debug($"Flushing the aggregator, currently has {buffer.Keys.Count} pending notifications");
+
+            foreach (var notification in buffer.Keys.ToList())
+            {
+                Flush(notification);
+            }
         }
 
         public void Dispose()
         {
             log.Debug("Disposing the aggregator");
-            if (timer != null)
+
+            canSend = false;
+            FlushAll();
+
+            timer?.Dispose();
+            timer = null;
+        }
+
+        struct NotificationForDeliveryEqualityComparer : IEqualityComparer<NotificationForDelivery>
+        {
+            public bool Equals(NotificationForDelivery x, NotificationForDelivery y)
             {
-                lock (this)
-                {
-                    Flush();
-                    timer?.Dispose();
-                    timer = null;
-                    canSend = false;
-                }
+                return x.Id.Equals(y.Id);
+            }
+
+            public int GetHashCode(NotificationForDelivery obj)
+            {
+                return obj.Id.GetHashCode();
             }
         }
     }

--- a/src/PushNotifications.Api.Host/PushNotifications.Api.Host.rn.md
+++ b/src/PushNotifications.Api.Host/PushNotifications.Api.Host.rn.md
@@ -1,3 +1,6 @@
+#### 5.0.4 - 14.08.2018
+* Builds MessageId from the request when sending a push notificaiton
+
 #### 5.0.3 - 14.08.2018
 * Fixes the TopicSubsciptionTracker endpoint
 

--- a/src/PushNotifications.Ports/PushNotificationsPort.cs
+++ b/src/PushNotifications.Ports/PushNotificationsPort.cs
@@ -49,7 +49,10 @@ namespace PushNotifications.Ports
                     {
                         var subscribtionId = new SubscriptionId(failedToken.Token, @event.Id.Tenant);
                         var unsubscribe = new UnSubscribe(subscribtionId, @event.SubscriberId, failedToken);
-                        CommandPublisher.Publish(unsubscribe);
+                        if (CommandPublisher.Publish(unsubscribe) == false)
+                        {
+                            log.Error("Unable to publish command" + Environment.NewLine + unsubscribe.ToString());
+                        }
                     }
                 }
             }

--- a/src/PushNotifications.WS.MSI/PushNotifications.WS.MSI.rn.md
+++ b/src/PushNotifications.WS.MSI/PushNotifications.WS.MSI.rn.md
@@ -1,3 +1,7 @@
+#### 5.0.3 - 14.08.2018
+* Logs an error when unsubscribe command fails to be published
+* Reworks the InMemoryPushNotificationAggregator. The access to the internal buffer is synchronized and sends all notifications when the entire buffer is flushed
+
 #### 5.0.2 - 14.08.2018
 * Fixes the TopicSubsciptionTracker endpoint
 


### PR DESCRIPTION
* Logs an error when unsubscribe command fails to be published
* Reworks the InMemoryPushNotificationAggregator. The access to the internal buffer is synchronized and sends all notifications when the entire buffer is flushed
* Builds MessageId from the request when sending a push notification