### PR TITLE
Mutable content header

### DIFF
--- a/src/PushNotifications.Delivery.FireBase/Models/FireBaseSendModel.cs
+++ b/src/PushNotifications.Delivery.FireBase/Models/FireBaseSendModel.cs
@@ -21,6 +21,7 @@ namespace PushNotifications.Delivery.FireBase.Models
             TTL = ExpirationTimeToSeconds(expiresAt);
             Data = notificationData;
             Priority = "high";
+            MutableContent = true;
         }
 
         /// <summary>
@@ -57,6 +58,15 @@ namespace PushNotifications.Delivery.FireBase.Models
         /// </summary>
         [JsonProperty(PropertyName = "time_to_live")]
         public long TTL { get; private set; }
+
+
+        /// <summary>
+        /// Currently for iOS 10+ devices only. On iOS, use this field to represent mutable-content in the APNs payload.
+        /// When a notification is sent and this is set to true, the content of the notification can be modified before it is displayed, using a Notification Service app extension.
+        /// This parameter will be ignored for Android and web.
+        /// </summary>
+        [JsonProperty(PropertyName = "mutable_content")]
+        public bool MutableContent { get; private set; }
 
         long ExpirationTimeToSeconds(Timestamp t)
         {

--- a/src/PushNotifications.Delivery.FireBase/Models/FireBaseTopicSendModel.cs
+++ b/src/PushNotifications.Delivery.FireBase/Models/FireBaseTopicSendModel.cs
@@ -21,6 +21,7 @@ namespace PushNotifications.Delivery.FireBase.Models
             TTL = ExpirationTimeToSeconds(expiresAt);
             Data = notificationData;
             Priority = "high";
+            MutableContent = true;
         }
 
         /// <summary>
@@ -57,6 +58,14 @@ namespace PushNotifications.Delivery.FireBase.Models
         /// </summary>
         [JsonProperty(PropertyName = "time_to_live")]
         public long TTL { get; private set; }
+
+        /// <summary>
+        /// Currently for iOS 10+ devices only. On iOS, use this field to represent mutable-content in the APNs payload.
+        /// When a notification is sent and this is set to true, the content of the notification can be modified before it is displayed, using a Notification Service app extension.
+        /// This parameter will be ignored for Android and web.
+        /// </summary>
+        [JsonProperty(PropertyName = "mutable_content")]
+        public bool MutableContent { get; private set; }
 
         long ExpirationTimeToSeconds(Timestamp t)
         {

--- a/src/PushNotifications.WS.MSI/PushNotifications.WS.MSI.rn.md
+++ b/src/PushNotifications.WS.MSI/PushNotifications.WS.MSI.rn.md
@@ -1,3 +1,6 @@
+#### 5.0.3 - 11.10.2018
+* Adds content_mutable flag for IOS with default to true
+
 #### 5.0.2 - 15.08.2018
 * Fixes the TopicSubsciptionTracker endpoint
 * * Logs an error when unsubscribe command fails to be published


### PR DESCRIPTION
Including this flag upon sending a push notification via Firebase, IOS devices can intercept and handle the push-notification for any internal logic.